### PR TITLE
Fix HeadsUp won't show on reload

### DIFF
--- a/GUI/Views/HeadsUpView.lua
+++ b/GUI/Views/HeadsUpView.lua
@@ -424,6 +424,9 @@ function headsUpView:Create()
     self.data.view.WhirlingSurge = ws
 
     self.data.view:Hide()
+
+    -- Try to show power bar if it's already active
+    events:UNIT_POWER_BAR_SHOW()
 end
 
 ---@return cbObject


### PR DESCRIPTION
Thanks for the nice addon, really feel like a pro flying around with a speed dash like this

This PR will make sure the speed dash shows up correctly when UI is reloaded, or the addon is loaded on the dragon's back

This is necessary due to some recent 11.0 bug that pitch control is sometimes compromised if you use whirling surge to start your race, and reloading the UI is a good fix for that
